### PR TITLE
WIP Add telemetry option(s) to www interface

### DIFF
--- a/data_embed/index.html
+++ b/data_embed/index.html
@@ -97,6 +97,10 @@
                         <label for="aprs_batt">Show Battery</label>
                         <input name="aprs_batt" id="aprs_batt" type="checkbox" value="1" title=" show battery voltage after personal comment">
                     </div>
+                    <div>
+                        <label for="aprs_self_tel">Enable Self Telemetry</label>
+                        <input name="aprs_self_tel" id="aprs_self_tel" type="checkbox" value="1" title=" send self telemetry data">
+                    </div>
                 </div>
                 <div class="grid-container full">
                     <h5 class="u-full-width">Fixed Beaconing Settings</h5>

--- a/data_embed/index.html
+++ b/data_embed/index.html
@@ -98,8 +98,12 @@
                         <input name="aprs_batt" id="aprs_batt" type="checkbox" value="1" title=" show battery voltage after personal comment">
                     </div>
                     <div>
-                        <label for="aprs_self_tel">Enable Self Telemetry</label>
-                        <input name="aprs_self_tel" id="aprs_self_tel" type="checkbox" value="1" title=" send self telemetry data">
+                        <label for="tnc_tel">Enable Self Telemetry</label>
+                        <input name="tnc_tel" id="tnc_tel" type="checkbox" value="1" title=" send self telemetry data">
+                    </div>
+                    <div>
+                        <label for="tnc_tel_int">Self Telemetry Interval [s]</label>
+                        <input name="tnc_tel_int" id="tnc_tel_int" type="number" min="10" title="time between sending telemetry if Enable Self Telemetry option is selected ">
                     </div>
                 </div>
                 <div class="grid-container full">

--- a/include/preference_storage.h
+++ b/include/preference_storage.h
@@ -7,7 +7,7 @@
 #define ENABLE_PREFERENCES
 extern Preferences preferences;
 
-// MAX 15 chars for preferenece key!!!
+// MAX 15 chars for preference key!!!
 static const char *const PREF_WIFI_SSID = "wifi_ssid";
 static const char *const PREF_WIFI_PASSWORD = "wifi_password";
 // LoRa settings
@@ -35,6 +35,8 @@ static const char *const PREF_APRS_FIXED_BEACON_PRESET = "aprs_fixed_beac";
 static const char *const PREF_APRS_FIXED_BEACON_PRESET_INIT = "aprs_fix_b_init";
 static const char *const PREF_APRS_FIXED_BEACON_INTERVAL_PRESET = "aprs_fb_interv";
 static const char *const PREF_APRS_FIXED_BEACON_INTERVAL_PRESET_INIT = "aprs_fb_in_init";
+static const char *const PREF_ENABLE_TNC_SELF_TELEMETRY = "aprs_self_tel";
+static const char *const PREF_ENABLE_TNC_SELF_TELEMETRY_INIT = "aprs_self_tel_i";
 // SMART BEACONING
 static const char *const PREF_APRS_SB_MIN_INTERVAL_PRESET = "sb_min_interv";
 static const char *const PREF_APRS_SB_MIN_INTERVAL_PRESET_INIT = "sb_min_interv_i";

--- a/include/preference_storage.h
+++ b/include/preference_storage.h
@@ -35,8 +35,10 @@ static const char *const PREF_APRS_FIXED_BEACON_PRESET = "aprs_fixed_beac";
 static const char *const PREF_APRS_FIXED_BEACON_PRESET_INIT = "aprs_fix_b_init";
 static const char *const PREF_APRS_FIXED_BEACON_INTERVAL_PRESET = "aprs_fb_interv";
 static const char *const PREF_APRS_FIXED_BEACON_INTERVAL_PRESET_INIT = "aprs_fb_in_init";
-static const char *const PREF_ENABLE_TNC_SELF_TELEMETRY = "aprs_self_tel";
-static const char *const PREF_ENABLE_TNC_SELF_TELEMETRY_INIT = "aprs_self_tel_i";
+static const char *const PREF_ENABLE_TNC_SELF_TELEMETRY = "tnc_tel";
+static const char *const PREF_ENABLE_TNC_SELF_TELEMETRY_INIT = "tnc_tel_i";
+static const char *const PREF_TNC_SELF_TELEMETRY_INTERVAL = "tnc_tel_int";
+static const char *const PREF_TNC_SELF_TELEMETRY_INTERVAL_INIT = "tnc_tel_int_i";
 // SMART BEACONING
 static const char *const PREF_APRS_SB_MIN_INTERVAL_PRESET = "sb_min_interv";
 static const char *const PREF_APRS_SB_MIN_INTERVAL_PRESET_INIT = "sb_min_interv_i";

--- a/include/preference_storage.h
+++ b/include/preference_storage.h
@@ -39,6 +39,8 @@ static const char *const PREF_ENABLE_TNC_SELF_TELEMETRY = "tnc_tel";
 static const char *const PREF_ENABLE_TNC_SELF_TELEMETRY_INIT = "tnc_tel_i";
 static const char *const PREF_TNC_SELF_TELEMETRY_INTERVAL = "tnc_tel_int";
 static const char *const PREF_TNC_SELF_TELEMETRY_INTERVAL_INIT = "tnc_tel_int_i";
+static const char *const PREF_TNC_SELF_TELEMETRY_SEQ = "tnc_tel_seq";
+static const char *const PREF_TNC_SELF_TELEMETRY_SEQ_INIT = "tnc_tel_seq_i";
 // SMART BEACONING
 static const char *const PREF_APRS_SB_MIN_INTERVAL_PRESET = "sb_min_interv";
 static const char *const PREF_APRS_SB_MIN_INTERVAL_PRESET_INIT = "sb_min_interv_i";

--- a/platformio.ini
+++ b/platformio.ini
@@ -52,6 +52,7 @@ build_flags =
 			-D 'MAX_TIME_TO_NEXT_TX=120000L'	; can be set from www interfeace
 			-D 'FIX_BEACON_INTERVAL=1800000L'	; can be set from www interfeace
 			-D 'NETWORK_GPS_PORT=10110'			; GPS NMEA Port
+			-D 'ENABLE_TNC_SELF_TELEMETRY'		; send telemetry data about device
 
 [env:ttgo-t-beam-v1.0]
 platform = espressif32 @ 3.0.0

--- a/platformio.ini
+++ b/platformio.ini
@@ -53,7 +53,8 @@ build_flags =
 			-D 'FIX_BEACON_INTERVAL=1800000L'	; can be set from www interface
 			-D 'NETWORK_GPS_PORT=10110'			; GPS NMEA Port
 			-D 'ENABLE_TNC_SELF_TELEMETRY'		; can be set from www interface
-			-D 'TNC_SELF_TELEMETRY_INTERVAL=60L' ; telemetry interval (milliseconds)
+			-D 'TNC_SELF_TELEMETRY_INTERVAL=3600L' ; can be set from www interface (seconds)
+			-D 'TNC_SELF_TELEMETRY_SEQ=0L'
 
 [env:ttgo-t-beam-v1.0]
 platform = espressif32 @ 3.0.0

--- a/platformio.ini
+++ b/platformio.ini
@@ -52,8 +52,8 @@ build_flags =
 			-D 'MAX_TIME_TO_NEXT_TX=120000L'	; can be set from www interface
 			-D 'FIX_BEACON_INTERVAL=1800000L'	; can be set from www interface
 			-D 'NETWORK_GPS_PORT=10110'			; GPS NMEA Port
-			-D 'ENABLE_TNC_SELF_TELEMETRY'		; send telemetry data about device
-			-D 'TNC_SELF_TELEMETRY_INTERVAL=60000L' ; telemetry interval (milliseconds)
+			-D 'ENABLE_TNC_SELF_TELEMETRY'		; can be set from www interface
+			-D 'TNC_SELF_TELEMETRY_INTERVAL=60L' ; telemetry interval (milliseconds)
 
 [env:ttgo-t-beam-v1.0]
 platform = espressif32 @ 3.0.0

--- a/platformio.ini
+++ b/platformio.ini
@@ -31,29 +31,29 @@ lib_deps =
 build_flags =
 			-Wl,--gc-sections,--relax
 			-D 'KISS_PROTOCOL'					; leave enabled
-			-D 'CALLSIGN="N0CALL-0"'			; can be set from www interfeace
-			-D 'DIGI_PATH="WIDE1-1"'			; can be set from www interfeace
-			-D 'FIXED_BEACON_EN'				; can be set from www interfeace
-			-D 'LATIDUDE_PRESET="0000.00N"'		; can be set from www interfeace
-			-D 'LONGITUDE_PRESET="00000.00E"'	; can be set from www interfeace
-			-D 'APRS_SYMBOL_TABLE="/"'			; can be set from www interfeace
-			-D 'APRS_SYMBOL="["'				; can be set from www interfeace
-			-D 'MY_COMMENT="Lora Tracker"'		; can be set from www interfeace
-			-D 'SHOW_ALT'						; can be set from www interfeace
-			-D 'SHOW_BATT'						; can be set from www interfeace
-			-D 'SHOW_RX_PACKET'					; can be set from www interfeace
-			-D 'SHOW_RX_TIME=10000' 			; can be set from www interfeace
+			-D 'CALLSIGN="N0CALL-0"'			; can be set from www interface
+			-D 'DIGI_PATH="WIDE1-1"'			; can be set from www interface
+			-D 'FIXED_BEACON_EN'				; can be set from www interface
+			-D 'LATIDUDE_PRESET="0000.00N"'		; can be set from www interface
+			-D 'LONGITUDE_PRESET="00000.00E"'	; can be set from www interface
+			-D 'APRS_SYMBOL_TABLE="/"'			; can be set from www interface
+			-D 'APRS_SYMBOL="["'				; can be set from www interface
+			-D 'MY_COMMENT="Lora Tracker"'		; can be set from www interface
+			-D 'SHOW_ALT'						; can be set from www interface
+			-D 'SHOW_BATT'						; can be set from www interface
+			-D 'SHOW_RX_PACKET'					; can be set from www interface
+			-D 'SHOW_RX_TIME=10000' 			; can be set from www interface
 			-D 'TXFREQ=433.775'					; set operating frequency
 			-D 'SPEED_1200'						; comment out to set 300baud
 			-D 'TXdbmW=23'						; set power
-			-D 'ENABLE_OLED'					; can be set from www interfeace
-			-D 'ENABLE_LED_SIGNALING'			; can be set from www interfeace
+			-D 'ENABLE_OLED'					; can be set from www interface
+			-D 'ENABLE_LED_SIGNALING'			; can be set from www interface
 			-D 'NETWORK_TNC_PORT=8001'			; default KISS TCP port
-			-D 'MAX_TIME_TO_NEXT_TX=120000L'	; can be set from www interfeace
-			-D 'FIX_BEACON_INTERVAL=1800000L'	; can be set from www interfeace
+			-D 'MAX_TIME_TO_NEXT_TX=120000L'	; can be set from www interface
+			-D 'FIX_BEACON_INTERVAL=1800000L'	; can be set from www interface
 			-D 'NETWORK_GPS_PORT=10110'			; GPS NMEA Port
 			-D 'ENABLE_TNC_SELF_TELEMETRY'		; send telemetry data about device
-			-D 'TNC_SELF_TELEMETRY_INTERVAL=1800000L' ; telemetry interval
+			-D 'TNC_SELF_TELEMETRY_INTERVAL=60000L' ; telemetry interval (milliseconds)
 
 [env:ttgo-t-beam-v1.0]
 platform = espressif32 @ 3.0.0

--- a/platformio.ini
+++ b/platformio.ini
@@ -53,6 +53,7 @@ build_flags =
 			-D 'FIX_BEACON_INTERVAL=1800000L'	; can be set from www interfeace
 			-D 'NETWORK_GPS_PORT=10110'			; GPS NMEA Port
 			-D 'ENABLE_TNC_SELF_TELEMETRY'		; send telemetry data about device
+			-D 'TNC_SELF_TELEMETRY_INTERVAL=1800000L' ; telemetry interval
 
 [env:ttgo-t-beam-v1.0]
 platform = espressif32 @ 3.0.0

--- a/src/TTGO_T-Beam_LoRa_APRS.ino
+++ b/src/TTGO_T-Beam_LoRa_APRS.ino
@@ -103,6 +103,7 @@ boolean key_up = true;
 boolean t_lock = false;
 boolean fixed_beacon_enabled = false;
 boolean show_cmt = true;
+int tel_interval;
 
 #ifdef SHOW_ALT
   boolean showAltitude = true;
@@ -139,7 +140,6 @@ String LatShown="";
 String LongFixed="";
 String LatFixed="";
 
-//#if (enable_tel == true) && defined(KISS_PROTOCOL)
 #if defined(ENABLE_TNC_SELF_TELEMETRY) && defined(KISS_PROTOCOL)
   time_t nextTelemetryFrame;
 #endif
@@ -485,7 +485,6 @@ String prepareCallsign(const String& callsign){
   return tmpString;
 }
 
-//#if (enable_tel == true) && defined(KISS_PROTOCOL)
 #if defined(ENABLE_TNC_SELF_TELEMETRY) && defined(KISS_PROTOCOL)
   void sendTelemetryFrame() {
     if(enable_tel == true){
@@ -527,6 +526,12 @@ void setup(){
   #else
     relay_path = "";
   #endif
+
+  //#ifdef TNC_SELF_TELEMETRY_INTERVAL
+  //  tel_interval = TNC_SELF_TELEMETRY_INTERVAL;
+  //#else
+  //  tel_interval = 60;
+  //#endif
 
   #ifdef FIXED_BEACON_EN
     fixed_beacon_enabled = true;
@@ -603,6 +608,12 @@ void setup(){
       preferences.putBool(PREF_ENABLE_TNC_SELF_TELEMETRY, enable_tel);
     }
     enable_tel = preferences.getBool(PREF_ENABLE_TNC_SELF_TELEMETRY);
+
+    if (!preferences.getBool(PREF_TNC_SELF_TELEMETRY_INTERVAL_INIT)){
+      preferences.putBool(PREF_TNC_SELF_TELEMETRY_INTERVAL_INIT, true);
+      preferences.putInt(PREF_TNC_SELF_TELEMETRY_INTERVAL, tel_interval);
+    }
+    tel_interval = preferences.getInt(PREF_TNC_SELF_TELEMETRY_INTERVAL);
 
     if (!preferences.getBool(PREF_APRS_LATITUDE_PRESET_INIT)){
       preferences.putBool(PREF_APRS_LATITUDE_PRESET_INIT, true);
@@ -1033,7 +1044,7 @@ void loop() {
   //#if (enable_tel == true) && defined(KISS_PROTOCOL)
   #if defined(ENABLE_TNC_SELF_TELEMETRY) && defined(KISS_PROTOCOL)
     if (nextTelemetryFrame < millis()){
-      nextTelemetryFrame = millis() + TNC_SELF_TELEMETRY_INTERVAL;
+      nextTelemetryFrame = millis() + (TNC_SELF_TELEMETRY_INTERVAL * 1000);
       sendTelemetryFrame();
     }
   #endif

--- a/src/TTGO_T-Beam_LoRa_APRS.ino
+++ b/src/TTGO_T-Beam_LoRa_APRS.ino
@@ -1044,7 +1044,7 @@ void loop() {
   //#if (enable_tel == true) && defined(KISS_PROTOCOL)
   #if defined(ENABLE_TNC_SELF_TELEMETRY) && defined(KISS_PROTOCOL)
     if (nextTelemetryFrame < millis()){
-      nextTelemetryFrame = millis() + (TNC_SELF_TELEMETRY_INTERVAL * 1000);
+      nextTelemetryFrame = millis() + (tel_interval * 1000);
       sendTelemetryFrame();
     }
   #endif

--- a/src/TTGO_T-Beam_LoRa_APRS.ino
+++ b/src/TTGO_T-Beam_LoRa_APRS.ino
@@ -494,11 +494,15 @@ String prepareCallsign(const String& callsign){
         uint8_t b_out_c = (axp.getBattDischargeCurrent()) / 10;
         uint8_t ac_volt = (axp.getVbusVoltage() - 3000) / 28;
         uint8_t ac_c = (axp.getVbusCurrent()) / 10;
+        // Pad telemetry message address to 9 characters
+        char Tcall_message_char[9];
+        sprintf_P(Tcall_message_char, "%-9s", Tcall);
+        String Tcall_message = String(Tcall_message_char);
 
-        String telemetryParamsNames = String(":") + Tcall + ":PARM.B Volt,B In,B Out,AC V,AC C";
-        String telemetryUnitNames = String(":") + Tcall + ":UNIT.mV,mA,mA,mV,mA";
-        String telemetryEquations = String(":") + Tcall + ":EQNS.0,5.1,3000,0,10,0,0,10,0,0,28,3000,0,10,0";
-        String telemetryData = String("T#MIC") + String(b_volt) + ","+ String(b_in_c) + ","+ String(b_out_c) + ","+ String(ac_volt) + ","+ String(ac_c) + ",00000000";
+        String telemetryParamsNames = String(":") + Tcall_message + ":PARM.B Volt,B In,B Out,AC V,AC C";
+        String telemetryUnitNames = String(":") + Tcall_message + ":UNIT.mV,mA,mA,mV,mA";
+        String telemetryEquations = String(":") + Tcall_message + ":EQNS.0,5.1,3000,0,10,0,0,10,0,0,28,3000,0,10,0";
+        String telemetryData = String("T#") + String(b_volt) + ","+ String(b_in_c) + ","+ String(b_out_c) + ","+ String(ac_volt) + ","+ String(ac_c) + ",00000000";
         String telemetryBase = "";
         telemetryBase += Tcall + ">APLO01," + relay_path + ":";
         Serial.print(telemetryBase);

--- a/src/TTGO_T-Beam_LoRa_APRS.ino
+++ b/src/TTGO_T-Beam_LoRa_APRS.ino
@@ -500,7 +500,8 @@ String prepareCallsign(const String& callsign){
         String telemetryEquations = String(":") + Tcall + ":EQNS.0,5.1,3000,0,10,0,0,10,0,0,28,3000,0,10,0";
         String telemetryData = String("T#MIC") + String(b_volt) + ","+ String(b_in_c) + ","+ String(b_out_c) + ","+ String(ac_volt) + ","+ String(ac_c) + ",00000000";
         String telemetryBase = "";
-        telemetryBase += Tcall + ">APLO01" + ":";
+        telemetryBase += Tcall + ">APLO01," + relay_path + ":";
+        Serial.print(telemetryBase);
         sendToTNC(telemetryBase + telemetryParamsNames);
         sendToTNC(telemetryBase + telemetryUnitNames);
         sendToTNC(telemetryBase + telemetryEquations);

--- a/src/taskWebServer.cpp
+++ b/src/taskWebServer.cpp
@@ -172,6 +172,7 @@ void handle_Cfg() {
   jsonData += jsonLineFromPreferenceBool(PREF_APRS_SHOW_ALTITUDE);
   jsonData += jsonLineFromPreferenceBool(PREF_APRS_GPS_EN);
   jsonData += jsonLineFromPreferenceBool(PREF_ENABLE_TNC_SELF_TELEMETRY);
+  jsonData += jsonLineFromPreferenceInt(PREF_TNC_SELF_TELEMETRY_INTERVAL);
   jsonData += jsonLineFromPreferenceBool(PREF_DEV_OL_EN);
   jsonData += jsonLineFromPreferenceBool(PREF_APRS_SHOW_CMT);
   jsonData += jsonLineFromPreferenceBool(PREF_DEV_BT_EN);
@@ -255,6 +256,9 @@ void handle_SaveAPRSCfg() {
   }
   if (server.hasArg(PREF_APRS_SB_ANGLE_PRESET)){
     preferences.putDouble(PREF_APRS_SB_ANGLE_PRESET, server.arg(PREF_APRS_SB_ANGLE_PRESET).toDouble());
+  }
+  if (server.hasArg(PREF_TNC_SELF_TELEMETRY_INTERVAL)){
+    preferences.putInt(PREF_TNC_SELF_TELEMETRY_INTERVAL, server.arg(PREF_TNC_SELF_TELEMETRY_INTERVAL).toInt());
   }
 
   preferences.putBool(PREF_APRS_SHOW_BATTERY, server.hasArg(PREF_APRS_SHOW_BATTERY));

--- a/src/taskWebServer.cpp
+++ b/src/taskWebServer.cpp
@@ -171,6 +171,7 @@ void handle_Cfg() {
   jsonData += jsonLineFromPreferenceBool(PREF_APRS_FIXED_BEACON_PRESET);
   jsonData += jsonLineFromPreferenceBool(PREF_APRS_SHOW_ALTITUDE);
   jsonData += jsonLineFromPreferenceBool(PREF_APRS_GPS_EN);
+  jsonData += jsonLineFromPreferenceBool(PREF_ENABLE_TNC_SELF_TELEMETRY);
   jsonData += jsonLineFromPreferenceBool(PREF_DEV_OL_EN);
   jsonData += jsonLineFromPreferenceBool(PREF_APRS_SHOW_CMT);
   jsonData += jsonLineFromPreferenceBool(PREF_DEV_BT_EN);
@@ -257,6 +258,7 @@ void handle_SaveAPRSCfg() {
   }
 
   preferences.putBool(PREF_APRS_SHOW_BATTERY, server.hasArg(PREF_APRS_SHOW_BATTERY));
+  preferences.putBool(PREF_ENABLE_TNC_SELF_TELEMETRY, server.hasArg(PREF_ENABLE_TNC_SELF_TELEMETRY));
   preferences.putBool(PREF_APRS_SHOW_ALTITUDE, server.hasArg(PREF_APRS_SHOW_ALTITUDE));
   preferences.putBool(PREF_APRS_FIXED_BEACON_PRESET, server.hasArg(PREF_APRS_FIXED_BEACON_PRESET));
   preferences.putBool(PREF_APRS_GPS_EN, server.hasArg(PREF_APRS_GPS_EN));


### PR DESCRIPTION
Will rebase this on parent fork once I get it working here. Followup from https://github.com/SQ9MDD/TTGO-T-Beam-LoRa-APRS/issues/59.

- [x] telementry enable in www
- [x] telemetry interval in www
- [ ] is unit scaling right? (https://github.com/mattbk/TTGO-T-Beam-LoRa-APRS/pull/2#issuecomment-917630495)
- [ ] allow digipeating path in www
    - [ ] make it work with empty path if provided (comma) or allow separate path for telemetry
- [ ] notify when sending telemetry (blink and/or screen)
     - [x] screen
     - [ ] flash LED
- [ ] work with IS websites?
    - [x] aprs.fi
    - [ ] aprsdirect.com
    - [ ] do they show the same data?
- [ ] bonus: choose which self telemetry values to send in www
- [ ] bonus: add www option for `MIC` telemetry rather than sequence